### PR TITLE
If new user is created, add info to Team Members table as well

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -75,6 +75,13 @@ router.post("/", async (req, res) => {
       // If user is not found, create a new User
       const newUser = await Users.add(userInfo);
 
+      await TeamMembers.add({
+        first_name: userInfo.name, 
+        last_name: userInfo.name, 
+        email: userInfo.email,
+        user_id: newUser.id
+      });
+
       // Respond to the client with a success message and the newly created User
       return res.status(201).json({
         message: "Account created Successfully",


### PR DESCRIPTION
Currently, a new user info is only added to the `Users` table. This PR adds the info to the `Team Members` table as well so that the team member can be looked up later.

This PR is the backend solution to routing a brand new user to `/home` on the frontend. Frontend PR #31